### PR TITLE
Fix unknown type forms a, b

### DIFF
--- a/frontend/src/features/forms/form-a-publications/form-a-schema.ts
+++ b/frontend/src/features/forms/form-a-publications/form-a-schema.ts
@@ -89,7 +89,7 @@ const formASchema = z.object({
   otherDB: z
    .string().optional(),
   citationNum: z
-    .coerce.number().nonnegative(),
+     .string().optional(),
   
   // A.4 Supporting Documents
   pubProof: z

--- a/frontend/src/features/forms/form-a-publications/form-a.tsx
+++ b/frontend/src/features/forms/form-a-publications/form-a.tsx
@@ -28,8 +28,7 @@ export default function FormAPublications() {
           pubmedMedline: "No",
           isChedRecognized: "No",
           peerRev: "No",
-          citationNum: "",
-          // Add other defaults here
+          citationNum: "0",
         }}
         onSubmit={onSubmit}
       />

--- a/frontend/src/features/forms/form-a-publications/form-a.tsx
+++ b/frontend/src/features/forms/form-a-publications/form-a.tsx
@@ -28,7 +28,7 @@ export default function FormAPublications() {
           pubmedMedline: "No",
           isChedRecognized: "No",
           peerRev: "No",
-          citationNum: 0,
+          citationNum: "",
           // Add other defaults here
         }}
         onSubmit={onSubmit}

--- a/frontend/src/features/forms/form-b-grants-and-fellowships/form-b-schema.ts
+++ b/frontend/src/features/forms/form-b-grants-and-fellowships/form-b-schema.ts
@@ -31,23 +31,14 @@ const formBSchema = z.object({
   
   //B.4  Funding
   upSystemResearchGrantPesos: z
-  .coerce.number({
-    message: "Please enter a valid amount.",
-    })
-    .nonnegative("Amount must be zero or greater.")
-    .default(0),
+    .string()
+    .min(1, "Please enter a valid amount that must be zero or greater."),
   externalFundingAmountPesos: z
-  .coerce.number({
-    message: "Please enter a valid amount.",
-    })
-    .nonnegative("Amount must be zero or greater.")
-    .default(0),
+    .string()
+    .min(1, "Please enter a valid amount that must be zero or greater."),
   totalFundingPesos: z
-  .coerce.number({
-    message: "Please enter a valid amount.",
-    })
-    .nonnegative("Amount must be zero or greater.")
-    .default(0),
+    .string()
+    .min(1, "Please enter a valid amount that must be zero or greater."),
   otherFundSource: z
    .string()
    .optional(),

--- a/frontend/src/features/forms/form-b-grants-and-fellowships/form-b.tsx
+++ b/frontend/src/features/forms/form-b-grants-and-fellowships/form-b.tsx
@@ -28,7 +28,6 @@ export default function FormBGrantsAndFellowships() {
           totalFundingPesos: "0.00",
           otherFundSource: "",
           majoritySource: "genFundCurYr",
-          // Add other defaults here
         }}
         onSubmit={onSubmit}
       />

--- a/frontend/src/features/forms/form-b-grants-and-fellowships/form-b.tsx
+++ b/frontend/src/features/forms/form-b-grants-and-fellowships/form-b.tsx
@@ -23,9 +23,9 @@ export default function FormBGrantsAndFellowships() {
           rEndDate: undefined,
           researchTimeframeMonths: "",
           researcherNames: "",
-          upSystemResearchGrantPesos: 0,
-          externalFundingAmountPesos: 0,
-          totalFundingPesos: 0,
+          upSystemResearchGrantPesos: "0.00",
+          externalFundingAmountPesos: "0.00",
+          totalFundingPesos: "0.00",
           otherFundSource: "",
           majoritySource: "genFundCurYr",
           // Add other defaults here


### PR DESCRIPTION
nonexistent form type "number" now removed, from `.coerce.number().nonnegative(),` to `.string().min(1, "Please enter a valid amount that must be zero or greater."),` in their respective form schemas for forms A and B